### PR TITLE
1.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ await sendGET<IHTTPBinResponse>(
 );
 // {
 //   code: 200,
+//   statusText: 'OK',
 //   headers: Headers {
 //     date: 'Fri, 06 Dec 2024 14:14:12 GMT',
 //     'content-type': 'application/json',
@@ -81,6 +82,7 @@ await sendPOST<IHTTPBinResponse>(
 );
 // {
 //   code: 200,
+//   statusText: 'OK',
 //   headers: Headers {
 //     date: 'Fri, 06 Dec 2024 12:57:25 GMT',
 //     'content-type': 'application/json',
@@ -133,6 +135,7 @@ await sendPOST<IHTTPBinResponse>(
   );
   // {
   //   code: 200,
+  //   statusText: 'OK',
   //   headers: Headers {
   //     date: 'Fri, 06 Dec 2024 13:05:20 GMT',
   //     'content-type': 'application/json',
@@ -168,6 +171,7 @@ await sendPOST<IHTTPBinResponse>(
   await sendGET<IHTTPBinResponse>('https://httpbin.org/get?foo=hey&bar=123');
   // {
   //   code: 200,
+  //   statusText: 'OK',
   //   headers: Headers {
   //     date: 'Fri, 06 Dec 2024 13:05:20 GMT',
   //     'content-type': 'application/json',
@@ -213,6 +217,7 @@ await sendPOST<IHTTPBinResponse>(
   );
   // {
   //   code: 200,
+  //   statusText: 'OK',
   //   headers: Headers {
   //     date: 'Fri, 06 Dec 2024 13:13:18 GMT',
   //     'content-type': 'application/json',
@@ -264,6 +269,7 @@ await sendPOST<IHTTPBinResponse>(
   );
   // {
   //   code: 200,
+  //   statusText: 'OK',
   //   headers: Headers {
   //     date: 'Fri, 06 Dec 2024 13:19:07 GMT',
   //     'content-type': 'application/json',
@@ -315,6 +321,7 @@ await sendPOST<IHTTPBinResponse>(
   );
   // {
   //   code: 200,
+  //   statusText: 'OK',
   //   headers: Headers {
   //     date: 'Fri, 06 Dec 2024 13:22:54 GMT',
   //     'content-type': 'application/json',
@@ -356,6 +363,7 @@ await sendPOST<IHTTPBinResponse>(
   await sendDELETE<IHTTPBinResponse>('https://httpbin.org/delete?id=1');
   // {
   //   code: 200,
+  //   statusText: 'OK',
   //   headers: Headers {
   //     date: 'Fri, 06 Dec 2024 13:25:41 GMT',
   //     'content-type': 'application/json',
@@ -517,6 +525,9 @@ await sendPOST<IHTTPBinResponse>(
   interface IRequestResponse<T> {
     // the HTTP status code extracted from the Response
     code: number;
+
+    // the message associated with the status code
+    statusText: string;
 
     // the Response's Headers. Useful as some service providers attach important info in the headers
     headers: Headers;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "fetch-request-browser",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetch-request-browser",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
-        "error-message-utils": "^1.1.2",
+        "error-message-utils": "^1.1.3",
         "web-utils-kit": "^1.0.5"
       },
       "devDependencies": {
@@ -1971,9 +1971,9 @@
       }
     },
     "node_modules/error-message-utils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/error-message-utils/-/error-message-utils-1.1.2.tgz",
-      "integrity": "sha512-IdxB7iL6cGEv/2NXTTh1OXKkZXhcPhFbXwPY/ytFSblSV81GjmYyI8w172UU+nl5Qqgz/EmlRgAj7Dj1mCkDbA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/error-message-utils/-/error-message-utils-1.1.3.tgz",
+      "integrity": "sha512-8zpjXZHHdO0cNb5WHCHXM+cRMJJcMw033NYzchnhv/Lo/h6no5ajM6D1rWyMNzDFZhMv6xlvjGbB7u28yB8XfA==",
       "license": "MIT"
     },
     "node_modules/es-abstract": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-request-browser",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "The fetch-request-browser package makes working with external APIs simple and efficient. This intuitive wrapper leverages the power of the Fetch API, providing a clean and concise interface for your API interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -42,7 +42,7 @@
     "vitest": "^1.6.1"
   },
   "dependencies": {
-    "error-message-utils": "^1.1.2",
+    "error-message-utils": "^1.1.3",
     "web-utils-kit": "^1.0.5"
   }
 }

--- a/src/index.test-integration.ts
+++ b/src/index.test-integration.ts
@@ -8,9 +8,10 @@ import { sendDELETE, sendGET, sendPATCH, sendPOST, sendPUT } from './index.js';
 describe('sendGET', () => {
   test('can send a GET request', async () => {
     const url = 'https://httpbin.org/get';
-    const { code, headers, data } = await sendGET<any>(url);
+    const { code, statusText, headers, data } = await sendGET<any>(url);
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 
@@ -24,9 +25,10 @@ describe('sendGET', () => {
 
   test('can send a GET request w/ query string', async () => {
     const url = 'https://httpbin.org/get?foo=hey&bar=123';
-    const { code, headers, data } = await sendGET<any>(url);
+    const { code, statusText, headers, data } = await sendGET<any>(url);
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 
@@ -49,9 +51,15 @@ describe('sendPOST', () => {
       someKey: 'Hello',
       someNumber: 123456,
     };
-    const { code, headers, data } = await sendPOST<any>(url, { requestOptions: { body } });
+    const {
+      code,
+      statusText,
+      headers,
+      data,
+    } = await sendPOST<any>(url, { requestOptions: { body } });
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 
@@ -76,9 +84,15 @@ describe('sendPUT', () => {
       someKey: 'Hello',
       someNumber: 123456,
     };
-    const { code, headers, data } = await sendPUT<any>(url, { requestOptions: { body } });
+    const {
+      code,
+      statusText,
+      headers,
+      data,
+    } = await sendPUT<any>(url, { requestOptions: { body } });
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 
@@ -103,9 +117,15 @@ describe('sendPATCH', () => {
       someKey: 'Hello',
       someNumber: 123456,
     };
-    const { code, headers, data } = await sendPATCH<any>(url, { requestOptions: { body } });
+    const {
+      code,
+      statusText,
+      headers,
+      data,
+    } = await sendPATCH<any>(url, { requestOptions: { body } });
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 
@@ -126,9 +146,10 @@ describe('sendPATCH', () => {
 describe('sendDELETE', () => {
   test('can send a DELETE request without a body', async () => {
     const url = 'https://httpbin.org/delete';
-    const { code, headers, data } = await sendDELETE<any>(url);
+    const { code, statusText, headers, data } = await sendDELETE<any>(url);
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 
@@ -147,9 +168,15 @@ describe('sendDELETE', () => {
       someKey: 'Hello',
       someNumber: 123456,
     };
-    const { code, headers, data } = await sendDELETE<any>(url, { requestOptions: { body } });
+    const {
+      code,
+      statusText,
+      headers,
+      data,
+    } = await sendDELETE<any>(url, { requestOptions: { body } });
 
     expect(code).toBe(200);
+    expect(statusText).toBe('OK');
 
     expect(headers.get('Content-Type')).toBe('application/json');
 

--- a/src/index.test-unit.ts
+++ b/src/index.test-unit.ts
@@ -35,11 +35,13 @@ describe('fetch-request', () => {
       const data = { success: true };
       vi.stubGlobal('fetch', vi.fn(async () => ({
         status: 200,
+        statusText: 'OK',
         headers,
         json: () => Promise.resolve(data),
       })));
       await expect(send('https://www.google.com')).resolves.toStrictEqual({
         code: 200,
+        statusText: 'OK',
         headers,
         data,
       });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -82,6 +82,9 @@ interface IRequestResponse<T> {
   // the HTTP status code extracted from the Response
   code: number;
 
+  // the message associated with the status code
+  statusText: string;
+
   // the Response's Headers. Useful as some service providers attach important info in the headers
   headers: Headers;
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,9 @@
-import { encodeError, isEncodedError } from 'error-message-utils';
+import {
+  encodeError,
+  extractMessage,
+  isDefaultErrorMessage,
+  isEncodedError,
+} from 'error-message-utils';
 import { isArrayValid, isObjectValid } from 'web-utils-kit';
 import { ERRORS } from '../shared/errors.js';
 import {
@@ -178,6 +183,23 @@ const extractResponseData = async <T>(
   }
 };
 
+/**
+ * Attempts to extract the error message from the response object. If it fails, it returns
+ * undefined.
+ * @param res
+ * @returns Promise<string | undefined>
+ * @stable
+ */
+const extractErrorMessageFromResponseBody = async (res: Response): Promise<string | undefined> => {
+  try {
+    const erroredBody = await res.json();
+    const message = extractMessage(erroredBody);
+    return isDefaultErrorMessage(message) ? undefined : message;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 
 
 
@@ -212,6 +234,7 @@ export {
 
   // response helpers
   extractResponseData,
+  extractErrorMessageFromResponseBody,
 
   // misc helpers
   buildOptions,


### PR DESCRIPTION
- Include `statusText` property to `IRequestResponse`
- Whenever a request fails, it attempts to extract the reason from the body. If found, it adds it as the cause in the Error instance. Otherwise, it **re-throws** the error